### PR TITLE
challenge clips: don't encode audio

### DIFF
--- a/services/scoring/server.py
+++ b/services/scoring/server.py
@@ -340,7 +340,7 @@ def upscale_video(input_path, scale_factor=2):
         "-c:v", "libx264",
         "-preset", "medium",  
         "-crf", "18",         
-        "-c:a", "copy",       
+        "-an",
         output_path
     ]
     

--- a/services/video_scheduler/video_utils.py
+++ b/services/video_scheduler/video_utils.py
@@ -78,7 +78,7 @@ def apply_color_space_transformation(video_path: str, output_path: str = None) -
         "ffmpeg", "-y", "-i", str(video_path),
         "-vf", selected_transformation,
         "-c:v", "libx264", "-preset", "fast", "-crf", "20",  # Faster preset, slightly higher CRF for speed
-        "-c:a", "aac", "-b:a", "128k",
+        "-an",
         str(output_path),
         "-hide_banner", "-loglevel", "error"
     ]
@@ -211,13 +211,13 @@ def download_trim_downscale_video(
             "taskset", "-c", "0,1,2,3,4,5,6,7,8,9,10,11",
             "ffmpeg", "-y", "-i", str(source_path), "-ss", str(start_time_clip), 
             "-t", str(actual_duration), "-c:v", "libx264", "-preset", "ultrafast",
-            "-c:a", "aac", str(clipped_path), "-hide_banner", "-loglevel", "error"
+            "-an", str(clipped_path), "-hide_banner", "-loglevel", "error"
         ]
         
         scale_cmd = [
             "taskset", "-c", "0,1,2,3,4,5,6,7,8,9,10,11",
             "ffmpeg", "-y", "-i", str(clipped_path), "-vf", f"scale=-1:{downscale_height}", 
-            "-c:v", "libx264", "-preset", "ultrafast", "-c:a", "aac", 
+            "-c:v", "libx264", "-preset", "ultrafast", "-an",
             str(downscale_path), "-hide_banner", "-loglevel", "error"
         ]
         
@@ -580,12 +580,12 @@ def download_trim_downscale_youtube_video(
         trim_cmd = [
             "ffmpeg", "-y", "-i", str(source_path), "-ss", str(start_time_clip), 
             "-t", str(actual_duration), "-c:v", "libx264", "-preset", "fast",
-            "-c:a", "aac", str(clipped_path), "-hide_banner", "-loglevel", "error"
+            "-an", str(clipped_path), "-hide_banner", "-loglevel", "error"
         ]
         
         scale_cmd = [
             "ffmpeg", "-y", "-i", str(clipped_path), "-vf", f"scale=-1:{downscale_height}", 
-            "-c:v", "libx264", "-preset", "fast", "-c:a", "aac", 
+            "-c:v", "libx264", "-preset", "fast", "-an",
             str(downscale_path), "-hide_banner", "-loglevel", "error"
         ]
         


### PR DESCRIPTION
The validator does not check audio at all, which is reasonable as the main task of the miner is to upscale and encode the video efficently and with the highest possible quality. Considering this, including audio tracks in challenge clips makes no sense.